### PR TITLE
fix: Moving asdf init to after path

### DIFF
--- a/.zshrc
+++ b/.zshrc
@@ -15,11 +15,6 @@ alias antibundle='antibody bundle < $HOME/.antibody-plugins > $HOME/.antibody-bu
 # e.g. config add ~/.zshrc to commit this file.
 alias config='git --git-dir=$HOME/.cfg --work-tree=$HOME'
 
-# ASDF
-# http://asdf-vm.com/
-# Add ASDF environment setup.
-source $(brew --prefix asdf)/libexec/asdf.sh
-
 # Granted
 # https://granted.dev/
 # Alias to switch profile and populate temporary credentials
@@ -65,6 +60,11 @@ export PATH=/usr/local/bin:$PATH
 export PATH=$HOME/bin:$PATH
 export PATH=/opt/homebrew/bin:$PATH
 export MANPATH=/usr/local/man:$MANPATH
+
+# ASDF
+# http://asdf-vm.com/
+# Add ASDF environment setup.
+source $(brew --prefix asdf)/libexec/asdf.sh
 
 # Use hyphen-insensitive completion
 HYPHEN_INSENSITIVE="true"


### PR DESCRIPTION
When tools, in this case python are installed with `asdf` globally, they're overwritten because the path declarations happen after the `asdf` env setup. In this case of python it's the one installed with Xcode tools. 

Before
![image](https://user-images.githubusercontent.com/1446907/188068922-62e392c2-2d3c-4b4d-8457-dfd5ef07f5b4.png)

After
![image](https://user-images.githubusercontent.com/1446907/188069038-6ecce8cc-0171-4b0f-84cc-a47ed20b5e7d.png)
